### PR TITLE
Gbyfh/dockerize dev cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM quay.io/parkside-securities/docker-parkside-runtime:ubuntu
-RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv emacs && \
+    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv emacs kubectl && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,6 @@ RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     mv lein /usr/local/bin && \
     lein -v && \
     mkdir -p /root/repos && \
-    curl https://pyenv.run | bash && \
-    export PATH="/root/.pyenv/bin:$PATH" && \
-    eval "$(pyenv init -)" && \
-    eval "$(pyenv virtualenv-init -)" && \
-    /root/.pyenv/bin/pyenv install 3.7.2 && \
-    /root/.pyenv/bin/pyenv install 2.7.15 && \
     git clone https://github.com/ingydotnet/git-subrepo /root/repos/git-subrepo && \
     git clone https://github.com/awslabs/git-secrets.git /root/repos/git-secrets && \
     cd /root/repos/git-secrets && make install && cd - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     mv lein /usr/local/bin && \
     lein -v && \
     mkdir -p /root/repos && \
+    curl https://pyenv.run | bash && \
+    /root/.pyenv/bin/pyenv install 3.7.2 && \
+    /root/.pyenv/bin/pyenv install 2.7.15 && \
     git clone https://github.com/ingydotnet/git-subrepo /root/repos/git-subrepo && \
     git clone https://github.com/awslabs/git-secrets.git /root/repos/git-secrets && \
     cd /root/repos/git-secrets && make install && cd - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,27 @@
 FROM quay.io/parkside-securities/docker-parkside-runtime:ubuntu
+ENV GOROOT /usr/local/go
+ENV GOPATH /root/go
+ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
+ENV PATH /root/repos/git-subrepo/lib:/usr/local/go/bin:${PATH}
+ENV MANPATH /root/repos/git-subrepo/man:$MANPATH
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update -yq && apt-get upgrade -yq && \
     apt-get install -yq git netcat rsync graphviz openvpn zsh direnv emacs kubectl && \
-    curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
+    curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
     rm -rf awscli-bundle* && \
-    go get -u -v github.com/kubernetes-sigs/aws-iam-authenticator/cmd/aws-iam-authenticator && \
+    wget -q https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz && \
+    tar -xvf go1.11.5.linux-amd64.tar.gz && \
+    mv go /usr/local && \
+    /usr/local/go/bin/go get -u -v github.com/kubernetes-sigs/aws-iam-authenticator/cmd/aws-iam-authenticator && \
+    rm go1.11.5.linux-amd64.tar.gz && \
     apt-get install -yq nodejs build-essential && \
     npm i npm@latest -g && \
     npm install --unsafe-perm -g @juxt/mach && \
-    wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
+    wget -q https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
     chmod +x lein && \
     mv lein /usr/local/bin && \
     lein -v && \
@@ -21,9 +30,6 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     git clone https://github.com/awslabs/git-secrets.git /root/repos/git-secrets && \
     cd /root/repos/git-secrets && make install && cd - && \
     apt-get clean
-ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
-ENV PATH /root/repos/git-subrepo/lib:${PATH}
-ENV MANPATH /root/repos/git-subrepo/man:$MANPATH
 COPY client.ovpn /etc/openvpn
 COPY entrypoint.sh /usr/local/bin
 COPY gitignore_global /root/gitignore_global

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/parkside-securities/docker-parkside-runtime:ubuntu
 RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv neovim && \
+    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,7 @@ COPY gitignore_global /root/gitignore_global
 COPY gitconfig /root/.gitconfig
 COPY bashrc /root/.bashrc
 COPY zshrc /root/.zshrc
+COPY nvim-install.sh /tmp/
+RUN  sh /tmp/nvim-install.sh && rm /tmp/nvim-install.sh 
 WORKDIR /parkside
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/parkside-securities/docker-parkside-runtime:ubuntu
 ENV GOROOT /usr/local/go
 ENV GOPATH /root/go
 ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
-ENV PATH /root/repos/git-subrepo/lib:/usr/local/go/bin:${PATH}
+ENV PATH /root/repos/git-subrepo/lib:/usr/local/go/bin:/root/go/bin:${PATH}
 ENV MANPATH /root/repos/git-subrepo/man:$MANPATH
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/parkside-securities/docker-parkside-runtime:ubuntu
 RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv && \
+    apt-get install -yq git netcat rsync graphviz openvpn zsh && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
@@ -15,8 +15,6 @@ RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     lein -v && \
     mkdir -p /root/repos && \
     git clone https://github.com/ingydotnet/git-subrepo /root/repos/git-subrepo && \
-    git clone https://github.com/awslabs/git-secrets.git /root/repos/git-secrets && \
-    cd /root/repos/git-secrets && make install && cd - && \
     apt-get clean
 ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
 ENV PATH /root/repos/git-subrepo/lib:${PATH}
@@ -25,7 +23,5 @@ COPY client.ovpn /etc/openvpn
 COPY entrypoint.sh /usr/local/bin
 COPY gitignore_global /root/gitignore_global
 COPY gitconfig /root/.gitconfig
-COPY bashrc /root/.bashrc
-COPY zshrc /root/.zshrc
 WORKDIR /parkside
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     lein -v && \
     mkdir -p /root/repos && \
     curl https://pyenv.run | bash && \
+    export PATH="/root/.pyenv/bin:$PATH" && \
+    eval "$(pyenv init -)" && \
+    eval "$(pyenv virtualenv-init -)" && \
     /root/.pyenv/bin/pyenv install 3.7.2 && \
     /root/.pyenv/bin/pyenv install 2.7.15 && \
     git clone https://github.com/ingydotnet/git-subrepo /root/repos/git-subrepo && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/parkside-securities/docker-parkside-runtime:ubuntu
 RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync graphviz openvpn zsh && \
+    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
@@ -15,6 +15,8 @@ RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     lein -v && \
     mkdir -p /root/repos && \
     git clone https://github.com/ingydotnet/git-subrepo /root/repos/git-subrepo && \
+    git clone https://github.com/awslabs/git-secrets.git /root/repos/git-secrets && \
+    cd /root/repos/git-secrets && make install && cd - && \
     apt-get clean
 ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
 ENV PATH /root/repos/git-subrepo/lib:${PATH}
@@ -23,5 +25,7 @@ COPY client.ovpn /etc/openvpn
 COPY entrypoint.sh /usr/local/bin
 COPY gitignore_global /root/gitignore_global
 COPY gitconfig /root/.gitconfig
+COPY bashrc /root/.bashrc
+COPY zshrc /root/.zshrc
 WORKDIR /parkside
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/parkside-securities/docker-parkside-runtime:ubuntu
 RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv && \
+    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv emacs && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
@@ -28,6 +28,6 @@ COPY gitconfig /root/.gitconfig
 COPY bashrc /root/.bashrc
 COPY zshrc /root/.zshrc
 COPY nvim-install.sh /tmp/
-RUN  sh /tmp/nvim-install.sh && rm /tmp/nvim-install.sh 
+RUN  sh /tmp/nvim-install.sh 
 WORKDIR /parkside
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,7 @@ ENV PATH /root/repos/git-subrepo/lib:${PATH}
 ENV MANPATH /root/repos/git-subrepo/man:$MANPATH
 COPY client.ovpn /etc/openvpn
 COPY entrypoint.sh /usr/local/bin
+COPY gitignore_global /root/gitignore_global
+COPY gitconfig /root/.gitconfig
 WORKDIR /parkside
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/parkside-securities/docker-parkside-runtime:ubuntu
 RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv && \
+    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv neovim && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv emacs kubectl && \
+    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv emacs kubectl less && \
     curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     lein -v && \
     mkdir -p /root/repos && \
     git clone https://github.com/ingydotnet/git-subrepo /root/repos/git-subrepo && \
+    git clone https://github.com/awslabs/git-secrets.git /root/repos/git-secrets && \
+    cd /root/repos/git-secrets && make install && cd - && \
     apt-get clean
 ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
 ENV PATH /root/repos/git-subrepo/lib:${PATH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/parkside-securities/docker-parkside-runtime:ubuntu
 RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync graphviz openvpn zsh && \
+    apt-get install -yq git netcat rsync graphviz openvpn zsh direnv && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
@@ -23,5 +23,7 @@ COPY client.ovpn /etc/openvpn
 COPY entrypoint.sh /usr/local/bin
 COPY gitignore_global /root/gitignore_global
 COPY gitconfig /root/.gitconfig
+COPY bashrc /root/.bashrc
+COPY zshrc /root/.zshrc
 WORKDIR /parkside
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
     rm -rf awscli-bundle* && \
+    go get -u -v github.com/kubernetes-sigs/aws-iam-authenticator/cmd/aws-iam-authenticator && \
     apt-get install -yq nodejs build-essential && \
     npm i npm@latest -g && \
     npm install --unsafe-perm -g @juxt/mach && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM clojure:tools-deps
+FROM quay.io/parkside-securities/docker-parkside-runtime:ubuntu
 RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq netcat rsync graphviz openvpn && \
+    apt-get install -yq git netcat rsync graphviz openvpn zsh && \
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
     unzip awscli-bundle.zip && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
@@ -12,5 +12,14 @@ RUN  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
     chmod +x lein && \
     mv lein /usr/local/bin && \
-    lein -v 
+    lein -v && \
+    mkdir -p /root/repos && \
+    git clone https://github.com/ingydotnet/git-subrepo /root/repos/git-subrepo && \
+    apt-get clean
+ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
+ENV PATH /root/repos/git-subrepo/lib:${PATH}
+ENV MANPATH /root/repos/git-subrepo/man:$MANPATH
 COPY client.ovpn /etc/openvpn
+COPY entrypoint.sh /usr/local/bin
+WORKDIR /parkside
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/bashrc
+++ b/bashrc
@@ -1,0 +1,1 @@
+eval "$(direnv hook bash)"

--- a/bashrc
+++ b/bashrc
@@ -1,1 +1,4 @@
 eval "$(direnv hook bash)"
+export PATH="/root/.pyenv/bin:$PATH"
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,9 @@ if [ -f /root/.ssh/id_rsa ] ; then
     ssh-add -k /root/.ssh/id_rsa
 fi
 
-eval $(envkey-source) && exec bash
+if [ "${ENVKEY}x" == "x" ]; then
+    echo "No ENVKEY is provided."
+    exec bash
+else
+    eval $(envkey-source) && exec bash
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,6 @@ if [ -f /root/.ssh/id_rsa ] ; then
 fi
 
 if [ "${ENVKEY}x" == "x" ]; then
-    echo "No ENVKEY is provided."
     exec bash
 else
     eval $(envkey-source) && exec bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash 
+
+if [ -f /root/.ssh/id_rsa ] ; then
+    eval "$(ssh-agent -s)"
+    ssh-add -k /root/.ssh/id_rsa
+fi
+
+eval $(envkey-source) && exec bash

--- a/gitconfig
+++ b/gitconfig
@@ -1,0 +1,2 @@
+[core]
+    excludesfile = /root/gitignore_global

--- a/gitignore_global
+++ b/gitignore_global
@@ -1,0 +1,216 @@
+# Created by https://www.gitignore.io/api/vim,emacs,linux,macos,clojure,intellij,leiningen
+# Edit at https://www.gitignore.io/?templates=vim,emacs,linux,macos,clojure,intellij,leiningen
+
+### Clojure ###
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/lib/
+/classes/
+/target/
+/checkouts/
+.lein-deps-sum
+.lein-repl-history
+.lein-plugins/
+.lein-failures
+.nrepl-port
+.cpcache/
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Leiningen ###
+
+### Linux ###
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.gitignore.io/api/vim,emacs,linux,macos,clojure,intellij,leiningen
+
+.nvimrc
+telepresence.log
+

--- a/nvim-install.sh
+++ b/nvim-install.sh
@@ -5,11 +5,11 @@
 #See: https://github.com/neovim/neovim/wiki/Building-Neovim#quick-start
 
 #Save current dir
-pushd .
+#pushd .
 
 #Install dependencies
-sudo apt-get update
-sudo apt-get install -y \
+apt-get update
+apt-get install -y \
   autoconf \
   automake \
   cmake \
@@ -22,7 +22,8 @@ sudo apt-get install -y \
   pkg-config \
   python-pip \
   software-properties-common \
-  unzip
+  unzip \
+  gettext
 
 #Get or update neovim github repo
 mkdir -p ~/src
@@ -51,7 +52,7 @@ pip2 install --user --upgrade neovim
 # sudo gem install neovim
 
 #Restore dir
-popd
+#popd
 
-echo "nvim command: $(which nvim)"
-echo "nvim command: $(ls -al "$(which nvim)")"
+#echo "nvim command: $(which nvim)"
+#echo "nvim command: $(ls -al "$(which nvim)")"

--- a/nvim-install.sh
+++ b/nvim-install.sh
@@ -21,8 +21,11 @@ apt-get install -y \
   libunibilium0 \
   pkg-config \
   python-pip \
+  python3-pip \
   software-properties-common \
   unzip \
+  ruby \
+  rubygems \
   gettext
 
 #Get or update neovim github repo
@@ -47,9 +50,13 @@ make install
 
 # Enable use of python plugins
 pip2 install --user --upgrade neovim
+pip3 install pynvim 
+pip3 install neovim 
 
 # Enable use of ruby plugins
-# sudo gem install neovim
+gem install neovim
+
+npm install -g neovim
 
 #Restore dir
 #popd

--- a/nvim-install.sh
+++ b/nvim-install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+#Build and install neovim for Debian
+#See: https://neovim.io/
+#See: https://github.com/neovim/neovim/wiki/Building-Neovim#quick-start
+
+#Save current dir
+pushd .
+
+#Install dependencies
+sudo apt-get update
+sudo apt-get install -y \
+  autoconf \
+  automake \
+  cmake \
+  g++ \
+  libncurses5-dev \
+  libtool \
+  libtool-bin \
+  libunibilium-dev \
+  libunibilium0 \
+  pkg-config \
+  python-pip \
+  software-properties-common \
+  unzip
+
+#Get or update neovim github repo
+mkdir -p ~/src
+cd ~/src || exit
+if [ ! -e ~/src/neovim ]; then
+  git clone https://github.com/neovim/neovim
+else
+  cd neovim || exit
+  git pull origin
+fi
+
+cd ~/src/neovim || exit
+git checkout master
+#Remove old build dir and .deps dir
+rm -rf build/
+rm -rf .deps/
+
+# Build and install neovim
+make CMAKE_BUILD_TYPE=RelWithDebInfo CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=/usr/local/"
+make install
+
+# Enable use of python plugins
+pip2 install --user --upgrade neovim
+
+# Enable use of ruby plugins
+# sudo gem install neovim
+
+#Restore dir
+popd
+
+echo "nvim command: $(which nvim)"
+echo "nvim command: $(ls -al "$(which nvim)")"

--- a/nvim-install.sh
+++ b/nvim-install.sh
@@ -28,6 +28,14 @@ apt-get install -y \
   rubygems \
   gettext
 
+
+curl https://pyenv.run | bash 
+export PATH="/root/.pyenv/bin:$PATH"
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+pyenv install 3.7.2
+pyenv install 2.7.15
+
 #Get or update neovim github repo
 mkdir -p ~/src
 cd ~/src || exit

--- a/nvim-install.sh
+++ b/nvim-install.sh
@@ -24,6 +24,9 @@ apt-get install -y \
   python3-pip \
   software-properties-common \
   unzip \
+  zlib1g-dev \
+  libffi-dev \
+  libssl-dev \
   ruby \
   rubygems \
   gettext
@@ -34,7 +37,6 @@ export PATH="/root/.pyenv/bin:$PATH"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 pyenv install 3.7.2
-pyenv install 2.7.15
 
 #Get or update neovim github repo
 mkdir -p ~/src

--- a/nvim-install.sh
+++ b/nvim-install.sh
@@ -37,6 +37,11 @@ export PATH="/root/.pyenv/bin:$PATH"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 pyenv install 3.7.2
+pyenv install 2.7.15
+pyenv virtualenv 3.7.2 neovim3
+pyenv virtualenv 2.7.15 neovim2
+pyenv local neovim3
+pip3 install pynvim neovim
 
 #Get or update neovim github repo
 mkdir -p ~/src

--- a/zshrc
+++ b/zshrc
@@ -1,0 +1,1 @@
+eval "$(direnv hook zsh)"


### PR DESCRIPTION
Added a number of new binaries to support [parkside-securities/pksd](https://github.com/parkside-securities/pksd). Verified the latest image can be used to build and test in Wercker for [account-service](https://app.wercker.com/parkside-securities/account-service/runs/deploy-ci/5c592021940b52009b74aa86) and [customer-graphql](https://app.wercker.com/parkside-securities/customer-graphql/runs/build/5c5922300f540f0075e650ec). 

The size was inflated and I may want to optimize, but I believe it's good enough as the starting point. 
