### PR TITLE
CLOUD-198 upgrade graphviz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ tags
 
 
 # End of https://www.gitignore.io/api/vim,macos,linux,emacs,clojure,leiningen
+
+.mach/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync zsh direnv emacs25 silversearcher-ag \
+    apt-get install -yq git netcat rsync zsh graphviz direnv emacs25 silversearcher-ag \
                         kubectl less zlib1g-dev libffi-dev libssl-dev vim-nox tmate libxss1 nodejs build-essential \
                         plantuml rlwrap && \
     apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync zsh graphviz direnv emacs25 silversearcher-ag \
+    apt-get install -yq git netcat rsync zsh libgd-dev fontconfig libcairo2-dev libpango1.0-dev libgts-dev \ 
+                        direnv emacs25 silversearcher-ag \
                         kubectl less zlib1g-dev libffi-dev libssl-dev vim-nox tmate libxss1 nodejs build-essential \
                         plantuml rlwrap && \
     apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync graphviz zsh direnv emacs25 silversearcher-ag \
+    apt-get install -yq git netcat rsync zsh direnv emacs25 silversearcher-ag \
                         kubectl less zlib1g-dev libffi-dev libssl-dev vim-nox tmate libxss1 nodejs build-essential \
                         plantuml rlwrap && \
     apt-get clean
@@ -28,6 +28,11 @@ RUN curl -s -LO https://github.com/kubernetes-sigs/kustomize/releases/download/k
     mv kustomize /usr/local/bin/kustomize && \
     rm kustomize_v3.3.0_linux_amd64.tar.gz && \
     chmod a+x /usr/local/bin/kustomize
+RUN curl -sL https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz -O && \
+    tar xvfp graphviz.tar.gz && \
+    cd  graphviz-* && \
+    ./configure && make && make install && \
+    cd - && rm -rf graphviz*
 
 ENV NVM_DIR /usr/local/nvm
 RUN mkdir -p $NVM_DIR && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync zsh libgd-dev fontconfig libcairo2-dev libpango1.0-dev libgts-dev \ 
+    apt-get install -yq git netcat rsync zsh libgd-dev fontconfig libcairo2-dev libpango1.0-dev libgts-dev graphviz \ 
                         direnv emacs25 silversearcher-ag \
                         kubectl less zlib1g-dev libffi-dev libssl-dev vim-nox tmate libxss1 nodejs build-essential \
                         plantuml rlwrap && \


### PR DESCRIPTION
- graphviz bundled as the deb package for Debian 9.9 is outdated. 
- I decided to compile the latest stable from the source code. 
- `configure` disables the feature to generate PNG if the prerequisites are missing. 
- I tried to add them individually, but still not sufficient. I resorted to add `graphviz`, then override the binary with the compiled one. 
- I ran all-repo builds with the updated `clojure-dev` and got three green builds in a row. 
    - https://drone-ci.parksidesecurities.io/parkside-securities/monorepo/9172
    - https://drone-ci.parksidesecurities.io/parkside-securities/monorepo/9174
    - https://drone-ci.parksidesecurities.io/parkside-securities/monorepo/9175

Here is the version info I got in the shell of `clojure-dev` docker container.
```
root@af9b3eee7e1a:/parkside# dot -V
dot - graphviz version 2.40.1 (20161225.0304)
```