### PR TITLE
#PKSD-7953 Change base to corretto-clojure and deploy to ECR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,12 +81,12 @@ RUN python -m venv /usr/local/dbt-env && \
     python -m pip install -U pip && \
     pip install wheel && \
     pip install dbt
-RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.1.0/drone_linux_amd64.tar.gz | tar zx && \
-    install -t /usr/local/bin drone
+# RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.1.0/drone_linux_amd64.tar.gz | tar zx && \
+    # install -t /usr/local/bin drone
 COPY entrypoint.sh /usr/local/bin
 COPY gitignore_global /root/gitignore_global
 COPY gitconfig /root/.gitconfig
 COPY bashrc /root/.bashrc
 COPY zshrc /root/.zshrc
-# WORKDIR /parkside
+WORKDIR /parkside
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REGISTRY=quay.io/parkside-securities
-FROM $REGISTRY/docker-parkside-runtime:fix-repository-54
+FROM $REGISTRY/docker-parkside-runtime:master-10
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /root/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add 
     libcairo2-dev libpango1.0-dev libgts-dev graphviz \
     emacs silversearcher-ag \
     kubectl less zlib1g-dev libffi-dev libssl-dev vim-nox tmate libxss1 \
-    build-essential plantuml jq && \
+    build-essential plantuml jq iproute2 && \
     apt-get clean
 RUN curl -sfL https://direnv.net/install.sh | bash
 RUN curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN mkdir -p /root/repos && \
     ln -s /root/repos/kubectx/kubectx /usr/local/bin/kubectx && \
     ln -s /root/repos/kubectx/kubens /usr/local/bin/kubens && \
     cd /root/repos/git-secrets && make install && cd - && \
-    curl https://pyenv.run | bash && \
+    curl -OL https://github.com/eraserhd/rep/releases/download/v0.1.2/rep-0.1.2-linux-amd64.tar.gz && \
     tar zxvfp rep-0.1.2-linux-amd64.tar.gz && \
     cp rep-0.1.2-linux-amd64/rep /usr/local/bin/rep && chmod a+x /usr/local/bin/rep && \
     cp rep-0.1.2-linux-amd64/rep.1 /usr/local/man/rep.1 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,12 +81,12 @@ RUN python -m venv /usr/local/dbt-env && \
     python -m pip install -U pip && \
     pip install wheel && \
     pip install dbt
-# RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.1.0/drone_linux_amd64.tar.gz | tar zx && \
-#     install -t /usr/local/bin drone
-# COPY entrypoint.sh /usr/local/bin
-# COPY gitignore_global /root/gitignore_global
-# COPY gitconfig /root/.gitconfig
+RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.1.0/drone_linux_amd64.tar.gz | tar zx && \
+    install -t /usr/local/bin drone
+COPY entrypoint.sh /usr/local/bin
+COPY gitignore_global /root/gitignore_global
+COPY gitconfig /root/.gitconfig
 # COPY bashrc /root/.bashrc
 # COPY zshrc /root/.zshrc
-# WORKDIR /parkside
-# ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+WORKDIR /parkside
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM quay.io/parkside-securities/docker-parkside-runtime:master-48
+ARG REGISTRY=quay.io/parkside-securities
+FROM $REGISTRY/docker-parkside-runtime:master-48
+
 ENV GOROOT /usr/local/go
 ENV GOPATH /root/go
 ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,54 +1,54 @@
 ARG REGISTRY=quay.io/parkside-securities
 FROM $REGISTRY/docker-parkside-runtime:master-55
 
-# ENV GOROOT /usr/local/go
-# ENV GOPATH /root/go
-# ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
-# ENV PATH /root/repos/git-subrepo/lib:/usr/local/go/bin:/root/go/bin:${PATH}
-# ENV MANPATH /root/repos/git-subrepo/man:$MANPATH
-# RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-#     echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
-#     apt-get update -yq && apt-get upgrade -yq && \
-#     apt-get install -yq git netcat rsync zsh libgd-dev fontconfig \
-#     libcairo2-dev libpango1.0-dev libgts-dev graphviz \
-#     emacs silversearcher-ag \
-#     kubectl less zlib1g-dev libffi-dev libssl-dev vim-nox tmate libxss1 \
-#     build-essential plantuml jq && \
-#     apt-get clean
-# RUN curl -sfL https://direnv.net/install.sh | bash
-# RUN curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
-#     unzip awscli-bundle.zip && \
-#     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-#     rm -rf awscli-bundle*
-# RUN wget -q https://dl.google.com/go/go1.11.11.linux-amd64.tar.gz && \
-#     tar -xvf go1.11.11.linux-amd64.tar.gz && \
-#     mv go /usr/local && \
-#     rm go1.11.11.linux-amd64.tar.gz
-# RUN curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.7/2019-03-27/bin/linux/amd64/aws-iam-authenticator && \
-#     chmod +x ./aws-iam-authenticator && \
-#     mv ./aws-iam-authenticator /usr/local/bin/
-# RUN curl -s -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.3.0/kustomize_v3.3.0_linux_amd64.tar.gz && \
-#     tar xzf kustomize_v3.3.0_linux_amd64.tar.gz && \
-#     mv kustomize /usr/local/bin/kustomize && \
-#     rm kustomize_v3.3.0_linux_amd64.tar.gz && \
-#     chmod a+x /usr/local/bin/kustomize
-# RUN curl -sL https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz -O && \
-#     tar xvfp graphviz.tar.gz && \
-#     cd  graphviz-* && \
-#     ./configure && make && make install && \
-#     cd - && rm -rf graphviz*
+ENV GOROOT /usr/local/go
+ENV GOPATH /root/go
+ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
+ENV PATH /root/repos/git-subrepo/lib:/usr/local/go/bin:/root/go/bin:${PATH}
+ENV MANPATH /root/repos/git-subrepo/man:$MANPATH
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
+    apt-get update -yq && apt-get upgrade -yq && \
+    apt-get install -yq git netcat rsync zsh libgd-dev fontconfig \
+    libcairo2-dev libpango1.0-dev libgts-dev graphviz \
+    emacs silversearcher-ag \
+    kubectl less zlib1g-dev libffi-dev libssl-dev vim-nox tmate libxss1 \
+    build-essential plantuml jq && \
+    apt-get clean
+RUN curl -sfL https://direnv.net/install.sh | bash
+RUN curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
+    unzip awscli-bundle.zip && \
+    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
+    rm -rf awscli-bundle*
+RUN wget -q https://dl.google.com/go/go1.11.11.linux-amd64.tar.gz && \
+    tar -xvf go1.11.11.linux-amd64.tar.gz && \
+    mv go /usr/local && \
+    rm go1.11.11.linux-amd64.tar.gz
+RUN curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.7/2019-03-27/bin/linux/amd64/aws-iam-authenticator && \
+    chmod +x ./aws-iam-authenticator && \
+    mv ./aws-iam-authenticator /usr/local/bin/
+RUN curl -s -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.3.0/kustomize_v3.3.0_linux_amd64.tar.gz && \
+    tar xzf kustomize_v3.3.0_linux_amd64.tar.gz && \
+    mv kustomize /usr/local/bin/kustomize && \
+    rm kustomize_v3.3.0_linux_amd64.tar.gz && \
+    chmod a+x /usr/local/bin/kustomize
+RUN curl -sL https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz -O && \
+    tar xvfp graphviz.tar.gz && \
+    cd  graphviz-* && \
+    ./configure && make && make install && \
+    cd - && rm -rf graphviz*
 
-# ENV REDIS_VERSION=6.2.1
-# RUN curl -OL https://download.redis.io/releases/redis-${REDIS_VERSION}.tar.gz && \
-#     tar xzf redis-${REDIS_VERSION}.tar.gz && \
-#     cd redis-${REDIS_VERSION} && \
-#     make install && \
-#     cp ./src/redis-server /usr/local/bin/ && \
-#     cp ./src/redis-benchmark /usr/local/bin/ && \
-#     cp ./src/redis-sentinel /usr/local/bin/ && \
-#     cp ./src/redis-cli /usr/local/bin/ && \
-#     chmod +x /usr/local/bin/redis-* && \
-#     rm -rf /tmp/redis-${REDIS_VERSION}
+ENV REDIS_VERSION=6.2.1
+RUN curl -OL https://download.redis.io/releases/redis-${REDIS_VERSION}.tar.gz && \
+    tar xzf redis-${REDIS_VERSION}.tar.gz && \
+    cd redis-${REDIS_VERSION} && \
+    make install && \
+    cp ./src/redis-server /usr/local/bin/ && \
+    cp ./src/redis-benchmark /usr/local/bin/ && \
+    cp ./src/redis-sentinel /usr/local/bin/ && \
+    cp ./src/redis-cli /usr/local/bin/ && \
+    chmod +x /usr/local/bin/redis-* && \
+    rm -rf /tmp/redis-${REDIS_VERSION}
 
 # RUN wget -q https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
 #     chmod +x lein && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,5 +88,5 @@ COPY gitignore_global /root/gitignore_global
 COPY gitconfig /root/.gitconfig
 COPY bashrc /root/.bashrc
 COPY zshrc /root/.zshrc
-WORKDIR /parkside
-# ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+# WORKDIR /parkside
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,92 +1,92 @@
 ARG REGISTRY=quay.io/parkside-securities
 FROM $REGISTRY/docker-parkside-runtime:master-55
 
-ENV GOROOT /usr/local/go
-ENV GOPATH /root/go
-ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
-ENV PATH /root/repos/git-subrepo/lib:/usr/local/go/bin:/root/go/bin:${PATH}
-ENV MANPATH /root/repos/git-subrepo/man:$MANPATH
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
-    apt-get update -yq && apt-get upgrade -yq && \
-    apt-get install -yq git netcat rsync zsh libgd-dev fontconfig \
-    libcairo2-dev libpango1.0-dev libgts-dev graphviz \
-    emacs silversearcher-ag \
-    kubectl less zlib1g-dev libffi-dev libssl-dev vim-nox tmate libxss1 \
-    build-essential plantuml jq && \
-    apt-get clean
-RUN curl -sfL https://direnv.net/install.sh | bash
-RUN curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
-    unzip awscli-bundle.zip && \
-    ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
-    rm -rf awscli-bundle*
-RUN wget -q https://dl.google.com/go/go1.11.11.linux-amd64.tar.gz && \
-    tar -xvf go1.11.11.linux-amd64.tar.gz && \
-    mv go /usr/local && \
-    rm go1.11.11.linux-amd64.tar.gz
-RUN curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.7/2019-03-27/bin/linux/amd64/aws-iam-authenticator && \
-    chmod +x ./aws-iam-authenticator && \
-    mv ./aws-iam-authenticator /usr/local/bin/
-RUN curl -s -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.3.0/kustomize_v3.3.0_linux_amd64.tar.gz && \
-    tar xzf kustomize_v3.3.0_linux_amd64.tar.gz && \
-    mv kustomize /usr/local/bin/kustomize && \
-    rm kustomize_v3.3.0_linux_amd64.tar.gz && \
-    chmod a+x /usr/local/bin/kustomize
-RUN curl -sL https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz -O && \
-    tar xvfp graphviz.tar.gz && \
-    cd  graphviz-* && \
-    ./configure && make && make install && \
-    cd - && rm -rf graphviz*
+# ENV GOROOT /usr/local/go
+# ENV GOPATH /root/go
+# ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
+# ENV PATH /root/repos/git-subrepo/lib:/usr/local/go/bin:/root/go/bin:${PATH}
+# ENV MANPATH /root/repos/git-subrepo/man:$MANPATH
+# RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+#     echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
+#     apt-get update -yq && apt-get upgrade -yq && \
+#     apt-get install -yq git netcat rsync zsh libgd-dev fontconfig \
+#     libcairo2-dev libpango1.0-dev libgts-dev graphviz \
+#     emacs silversearcher-ag \
+#     kubectl less zlib1g-dev libffi-dev libssl-dev vim-nox tmate libxss1 \
+#     build-essential plantuml jq && \
+#     apt-get clean
+# RUN curl -sfL https://direnv.net/install.sh | bash
+# RUN curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
+#     unzip awscli-bundle.zip && \
+#     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
+#     rm -rf awscli-bundle*
+# RUN wget -q https://dl.google.com/go/go1.11.11.linux-amd64.tar.gz && \
+#     tar -xvf go1.11.11.linux-amd64.tar.gz && \
+#     mv go /usr/local && \
+#     rm go1.11.11.linux-amd64.tar.gz
+# RUN curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.12.7/2019-03-27/bin/linux/amd64/aws-iam-authenticator && \
+#     chmod +x ./aws-iam-authenticator && \
+#     mv ./aws-iam-authenticator /usr/local/bin/
+# RUN curl -s -LO https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.3.0/kustomize_v3.3.0_linux_amd64.tar.gz && \
+#     tar xzf kustomize_v3.3.0_linux_amd64.tar.gz && \
+#     mv kustomize /usr/local/bin/kustomize && \
+#     rm kustomize_v3.3.0_linux_amd64.tar.gz && \
+#     chmod a+x /usr/local/bin/kustomize
+# RUN curl -sL https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz -O && \
+#     tar xvfp graphviz.tar.gz && \
+#     cd  graphviz-* && \
+#     ./configure && make && make install && \
+#     cd - && rm -rf graphviz*
 
-ENV REDIS_VERSION=6.2.1
-RUN curl -OL https://download.redis.io/releases/redis-${REDIS_VERSION}.tar.gz && \
-    tar xzf redis-${REDIS_VERSION}.tar.gz && \
-    cd redis-${REDIS_VERSION} && \
-    make install && \
-    cp ./src/redis-server /usr/local/bin/ && \
-    cp ./src/redis-benchmark /usr/local/bin/ && \
-    cp ./src/redis-sentinel /usr/local/bin/ && \
-    cp ./src/redis-cli /usr/local/bin/ && \
-    chmod +x /usr/local/bin/redis-* && \
-    rm -rf /tmp/redis-${REDIS_VERSION}
+# ENV REDIS_VERSION=6.2.1
+# RUN curl -OL https://download.redis.io/releases/redis-${REDIS_VERSION}.tar.gz && \
+#     tar xzf redis-${REDIS_VERSION}.tar.gz && \
+#     cd redis-${REDIS_VERSION} && \
+#     make install && \
+#     cp ./src/redis-server /usr/local/bin/ && \
+#     cp ./src/redis-benchmark /usr/local/bin/ && \
+#     cp ./src/redis-sentinel /usr/local/bin/ && \
+#     cp ./src/redis-cli /usr/local/bin/ && \
+#     chmod +x /usr/local/bin/redis-* && \
+#     rm -rf /tmp/redis-${REDIS_VERSION}
 
-RUN wget -q https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
-    chmod +x lein && \
-    mv lein /usr/local/bin && \
-    lein -v
-RUN mkdir -p /root/repos && \
-    git clone https://github.com/ingydotnet/git-subrepo /root/repos/git-subrepo && \
-    git clone https://github.com/awslabs/git-secrets.git /root/repos/git-secrets && \
-    git clone https://github.com/magicmonty/bash-git-prompt.git /root/.bash-git-prompt --depth=1 && \
-    git clone https://github.com/olivierverdier/zsh-git-prompt.git /root/.zsh-git-prompt && \
-    git clone https://github.com/jonmosco/kube-ps1.git /root/.kube-ps1 && \
-    git clone https://github.com/ahmetb/kubectx /root/repos/kubectx && \
-    chmod +x /root/repos/kubectx/kubectx && \
-    chmod +x /root/repos/kubectx/kubens && \
-    ln -s /root/repos/kubectx/kubectx /usr/local/bin/kubectx && \
-    ln -s /root/repos/kubectx/kubens /usr/local/bin/kubens && \
-    cd /root/repos/git-secrets && make install && cd - && \
-    curl -OL https://github.com/eraserhd/rep/releases/download/v0.1.2/rep-0.1.2-linux-amd64.tar.gz && \
-    tar zxvfp rep-0.1.2-linux-amd64.tar.gz && \
-    cp rep-0.1.2-linux-amd64/rep /usr/local/bin/rep && chmod a+x /usr/local/bin/rep && \
-    cp rep-0.1.2-linux-amd64/rep.1 /usr/local/man/rep.1 && \
-    rm -rf rep-0.1.2-linux-amd64 && \
-    npm install -g shadow-cljs
-RUN pip install mkdocs && \
-    pip install plantuml-markdown && \
-    pip install markdown-include && \
-    pip install mkdocs-rtd-dropdown
-RUN python -m venv /usr/local/dbt-env && \
-    . /usr/local/dbt-env/bin/activate && \
-    python -m pip install -U pip && \
-    pip install wheel && \
-    pip install dbt
-RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.1.0/drone_linux_amd64.tar.gz | tar zx && \
-    install -t /usr/local/bin drone
-COPY entrypoint.sh /usr/local/bin
-COPY gitignore_global /root/gitignore_global
-COPY gitconfig /root/.gitconfig
-COPY bashrc /root/.bashrc
-COPY zshrc /root/.zshrc
-WORKDIR /parkside
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+# RUN wget -q https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
+#     chmod +x lein && \
+#     mv lein /usr/local/bin && \
+#     lein -v
+# RUN mkdir -p /root/repos && \
+#     git clone https://github.com/ingydotnet/git-subrepo /root/repos/git-subrepo && \
+#     git clone https://github.com/awslabs/git-secrets.git /root/repos/git-secrets && \
+#     git clone https://github.com/magicmonty/bash-git-prompt.git /root/.bash-git-prompt --depth=1 && \
+#     git clone https://github.com/olivierverdier/zsh-git-prompt.git /root/.zsh-git-prompt && \
+#     git clone https://github.com/jonmosco/kube-ps1.git /root/.kube-ps1 && \
+#     git clone https://github.com/ahmetb/kubectx /root/repos/kubectx && \
+#     chmod +x /root/repos/kubectx/kubectx && \
+#     chmod +x /root/repos/kubectx/kubens && \
+#     ln -s /root/repos/kubectx/kubectx /usr/local/bin/kubectx && \
+#     ln -s /root/repos/kubectx/kubens /usr/local/bin/kubens && \
+#     cd /root/repos/git-secrets && make install && cd - && \
+#     curl -OL https://github.com/eraserhd/rep/releases/download/v0.1.2/rep-0.1.2-linux-amd64.tar.gz && \
+#     tar zxvfp rep-0.1.2-linux-amd64.tar.gz && \
+#     cp rep-0.1.2-linux-amd64/rep /usr/local/bin/rep && chmod a+x /usr/local/bin/rep && \
+#     cp rep-0.1.2-linux-amd64/rep.1 /usr/local/man/rep.1 && \
+#     rm -rf rep-0.1.2-linux-amd64 && \
+#     npm install -g shadow-cljs
+# RUN pip install mkdocs && \
+#     pip install plantuml-markdown && \
+#     pip install markdown-include && \
+#     pip install mkdocs-rtd-dropdown
+# RUN python -m venv /usr/local/dbt-env && \
+#     . /usr/local/dbt-env/bin/activate && \
+#     python -m pip install -U pip && \
+#     pip install wheel && \
+#     pip install dbt
+# RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.1.0/drone_linux_amd64.tar.gz | tar zx && \
+#     install -t /usr/local/bin drone
+# COPY entrypoint.sh /usr/local/bin
+# COPY gitignore_global /root/gitignore_global
+# COPY gitconfig /root/.gitconfig
+# COPY bashrc /root/.bashrc
+# COPY zshrc /root/.zshrc
+# WORKDIR /parkside
+# ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REGISTRY=quay.io/parkside-securities
-FROM $REGISTRY/docker-parkside-runtime:master-48
+FROM $REGISTRY/docker-parkside-runtime:fix-repository-54
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /root/go
@@ -13,7 +13,7 @@ RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add 
     libcairo2-dev libpango1.0-dev libgts-dev graphviz \
     emacs silversearcher-ag \
     kubectl less zlib1g-dev libffi-dev libssl-dev vim-nox tmate libxss1 \
-    build-essential plantuml jq python3-venv && \
+    build-essential plantuml jq && \
     apt-get clean
 RUN curl -sfL https://direnv.net/install.sh | bash
 RUN curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \
@@ -50,16 +50,6 @@ RUN curl -OL https://download.redis.io/releases/redis-${REDIS_VERSION}.tar.gz &&
     chmod +x /usr/local/bin/redis-* && \
     rm -rf /tmp/redis-${REDIS_VERSION}
 
-ENV NVM_DIR /usr/local/nvm
-RUN mkdir -p $NVM_DIR && \
-    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
-ENV NODE_VERSION v9.11.2
-RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION"
-ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/lib/node_modules
-ENV PATH      $NVM_DIR/versions/node/$NODE_VERSION/bin:$PATH
-RUN . $NVM_DIR/nvm.sh && \
-    nvm use default && \
-    npm install -g closh --unsafe-perm
 RUN wget -q https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
     chmod +x lein && \
     mv lein /usr/local/bin && \
@@ -77,9 +67,6 @@ RUN mkdir -p /root/repos && \
     ln -s /root/repos/kubectx/kubens /usr/local/bin/kubens && \
     cd /root/repos/git-secrets && make install && cd - && \
     curl https://pyenv.run | bash && \
-    /root/.pyenv/bin/pyenv install 3.7.2 && \
-    /root/.pyenv/bin/pyenv global 3.7.2 && \
-    curl -OL https://github.com/eraserhd/rep/releases/download/v0.1.2/rep-0.1.2-linux-amd64.tar.gz && \
     tar zxvfp rep-0.1.2-linux-amd64.tar.gz && \
     cp rep-0.1.2-linux-amd64/rep /usr/local/bin/rep && chmod a+x /usr/local/bin/rep && \
     cp rep-0.1.2-linux-amd64/rep.1 /usr/local/man/rep.1 && \
@@ -89,9 +76,9 @@ RUN pip install mkdocs && \
     pip install plantuml-markdown && \
     pip install markdown-include && \
     pip install mkdocs-rtd-dropdown
-RUN python3 -m venv /usr/local/dbt-env && \
+RUN python -m venv /usr/local/dbt-env && \
     . /usr/local/dbt-env/bin/activate && \
-    python3 -m pip install -U pip && \
+    python -m pip install -U pip && \
     pip install wheel && \
     pip install dbt
 RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.1.0/drone_linux_amd64.tar.gz | tar zx && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV GOPATH /root/go
 ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
 ENV PATH /root/repos/git-subrepo/lib:/usr/local/go/bin:/root/go/bin:${PATH}
 ENV MANPATH /root/repos/git-subrepo/man:$MANPATH
+RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.2.0/drone_linux_amd64.tar.gz | tar zx && \
+    install -t /usr/local/bin drone
 RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update -yq && apt-get upgrade -yq && \
@@ -81,8 +83,6 @@ RUN python -m venv /usr/local/dbt-env && \
     python -m pip install -U pip && \
     pip install wheel && \
     pip install dbt
-RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.2.0/drone_linux_amd64.tar.gz | tar zx && \
-    install -t /usr/local/bin drone
 COPY entrypoint.sh /usr/local/bin
 COPY gitignore_global /root/gitignore_global
 COPY gitconfig /root/.gitconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,17 @@
-FROM quay.io/parkside-securities/docker-parkside-runtime:ubuntu-21
+FROM quay.io/parkside-securities/docker-parkside-runtime:master-48
 ENV GOROOT /usr/local/go
 ENV GOPATH /root/go
 ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
 ENV PATH /root/repos/git-subrepo/lib:/usr/local/go/bin:/root/go/bin:${PATH}
 ENV MANPATH /root/repos/git-subrepo/man:$MANPATH
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
-    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update -yq && apt-get upgrade -yq && \
     apt-get install -yq git netcat rsync zsh libgd-dev fontconfig \
     libcairo2-dev libpango1.0-dev libgts-dev graphviz \
-    emacs25 silversearcher-ag \
+    emacs silversearcher-ag \
     kubectl less zlib1g-dev libffi-dev libssl-dev vim-nox tmate libxss1 \
-    nodejs build-essential plantuml rlwrap jq python3-venv && \
+    build-essential plantuml jq python3-venv && \
     apt-get clean
 RUN curl -sfL https://direnv.net/install.sh | bash
 RUN curl -s "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,15 +72,15 @@ RUN mkdir -p /root/repos && \
     cp rep-0.1.2-linux-amd64/rep.1 /usr/local/man/rep.1 && \
     rm -rf rep-0.1.2-linux-amd64 && \
     npm install -g shadow-cljs
-# RUN pip install mkdocs && \
-#     pip install plantuml-markdown && \
-#     pip install markdown-include && \
-#     pip install mkdocs-rtd-dropdown
-# RUN python -m venv /usr/local/dbt-env && \
-#     . /usr/local/dbt-env/bin/activate && \
-#     python -m pip install -U pip && \
-#     pip install wheel && \
-#     pip install dbt
+RUN pip install mkdocs && \
+    pip install plantuml-markdown && \
+    pip install markdown-include && \
+    pip install mkdocs-rtd-dropdown
+RUN python -m venv /usr/local/dbt-env && \
+    . /usr/local/dbt-env/bin/activate && \
+    python -m pip install -U pip && \
+    pip install wheel && \
+    pip install dbt
 # RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.1.0/drone_linux_amd64.tar.gz | tar zx && \
 #     install -t /usr/local/bin drone
 # COPY entrypoint.sh /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.1.0/drone_li
 COPY entrypoint.sh /usr/local/bin
 COPY gitignore_global /root/gitignore_global
 COPY gitconfig /root/.gitconfig
-# COPY bashrc /root/.bashrc
-# COPY zshrc /root/.zshrc
+COPY bashrc /root/.bashrc
+COPY zshrc /root/.zshrc
 WORKDIR /parkside
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+# ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,12 +81,12 @@ RUN python -m venv /usr/local/dbt-env && \
     python -m pip install -U pip && \
     pip install wheel && \
     pip install dbt
-RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.1.0/drone_linux_amd64.tar.gz | tar zx && \
+RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.2.0/drone_linux_amd64.tar.gz | tar zx && \
     install -t /usr/local/bin drone
-# COPY entrypoint.sh /usr/local/bin
-# COPY gitignore_global /root/gitignore_global
-# COPY gitconfig /root/.gitconfig
-# COPY bashrc /root/.bashrc
-# COPY zshrc /root/.zshrc
+COPY entrypoint.sh /usr/local/bin
+COPY gitignore_global /root/gitignore_global
+COPY gitconfig /root/.gitconfig
+COPY bashrc /root/.bashrc
+COPY zshrc /root/.zshrc
 WORKDIR /parkside
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,28 +50,28 @@ RUN curl -OL https://download.redis.io/releases/redis-${REDIS_VERSION}.tar.gz &&
     chmod +x /usr/local/bin/redis-* && \
     rm -rf /tmp/redis-${REDIS_VERSION}
 
-# RUN wget -q https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
-#     chmod +x lein && \
-#     mv lein /usr/local/bin && \
-#     lein -v
-# RUN mkdir -p /root/repos && \
-#     git clone https://github.com/ingydotnet/git-subrepo /root/repos/git-subrepo && \
-#     git clone https://github.com/awslabs/git-secrets.git /root/repos/git-secrets && \
-#     git clone https://github.com/magicmonty/bash-git-prompt.git /root/.bash-git-prompt --depth=1 && \
-#     git clone https://github.com/olivierverdier/zsh-git-prompt.git /root/.zsh-git-prompt && \
-#     git clone https://github.com/jonmosco/kube-ps1.git /root/.kube-ps1 && \
-#     git clone https://github.com/ahmetb/kubectx /root/repos/kubectx && \
-#     chmod +x /root/repos/kubectx/kubectx && \
-#     chmod +x /root/repos/kubectx/kubens && \
-#     ln -s /root/repos/kubectx/kubectx /usr/local/bin/kubectx && \
-#     ln -s /root/repos/kubectx/kubens /usr/local/bin/kubens && \
-#     cd /root/repos/git-secrets && make install && cd - && \
-#     curl -OL https://github.com/eraserhd/rep/releases/download/v0.1.2/rep-0.1.2-linux-amd64.tar.gz && \
-#     tar zxvfp rep-0.1.2-linux-amd64.tar.gz && \
-#     cp rep-0.1.2-linux-amd64/rep /usr/local/bin/rep && chmod a+x /usr/local/bin/rep && \
-#     cp rep-0.1.2-linux-amd64/rep.1 /usr/local/man/rep.1 && \
-#     rm -rf rep-0.1.2-linux-amd64 && \
-#     npm install -g shadow-cljs
+RUN wget -q https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
+    chmod +x lein && \
+    mv lein /usr/local/bin && \
+    lein -v
+RUN mkdir -p /root/repos && \
+    git clone https://github.com/ingydotnet/git-subrepo /root/repos/git-subrepo && \
+    git clone https://github.com/awslabs/git-secrets.git /root/repos/git-secrets && \
+    git clone https://github.com/magicmonty/bash-git-prompt.git /root/.bash-git-prompt --depth=1 && \
+    git clone https://github.com/olivierverdier/zsh-git-prompt.git /root/.zsh-git-prompt && \
+    git clone https://github.com/jonmosco/kube-ps1.git /root/.kube-ps1 && \
+    git clone https://github.com/ahmetb/kubectx /root/repos/kubectx && \
+    chmod +x /root/repos/kubectx/kubectx && \
+    chmod +x /root/repos/kubectx/kubens && \
+    ln -s /root/repos/kubectx/kubectx /usr/local/bin/kubectx && \
+    ln -s /root/repos/kubectx/kubens /usr/local/bin/kubens && \
+    cd /root/repos/git-secrets && make install && cd - && \
+    curl -OL https://github.com/eraserhd/rep/releases/download/v0.1.2/rep-0.1.2-linux-amd64.tar.gz && \
+    tar zxvfp rep-0.1.2-linux-amd64.tar.gz && \
+    cp rep-0.1.2-linux-amd64/rep /usr/local/bin/rep && chmod a+x /usr/local/bin/rep && \
+    cp rep-0.1.2-linux-amd64/rep.1 /usr/local/man/rep.1 && \
+    rm -rf rep-0.1.2-linux-amd64 && \
+    npm install -g shadow-cljs
 # RUN pip install mkdocs && \
 #     pip install plantuml-markdown && \
 #     pip install markdown-include && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ ENV GOPATH /root/go
 ENV GIT_SUBREPO_ROOT /root/repos/git-subrepo
 ENV PATH /root/repos/git-subrepo/lib:/usr/local/go/bin:/root/go/bin:${PATH}
 ENV MANPATH /root/repos/git-subrepo/man:$MANPATH
-RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.2.0/drone_linux_amd64.tar.gz | tar zx && \
-    install -t /usr/local/bin drone
 RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
     apt-get update -yq && apt-get upgrade -yq && \
@@ -34,11 +32,6 @@ RUN curl -s -LO https://github.com/kubernetes-sigs/kustomize/releases/download/k
     mv kustomize /usr/local/bin/kustomize && \
     rm kustomize_v3.3.0_linux_amd64.tar.gz && \
     chmod a+x /usr/local/bin/kustomize
-RUN curl -sL https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz -O && \
-    tar xvfp graphviz.tar.gz && \
-    cd  graphviz-* && \
-    ./configure && make && make install && \
-    cd - && rm -rf graphviz*
 
 ENV REDIS_VERSION=6.2.1
 RUN curl -OL https://download.redis.io/releases/redis-${REDIS_VERSION}.tar.gz && \
@@ -83,6 +76,8 @@ RUN python -m venv /usr/local/dbt-env && \
     python -m pip install -U pip && \
     pip install wheel && \
     pip install dbt
+RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.2.0/drone_linux_amd64.tar.gz | tar zx && \
+    install -t /usr/local/bin drone
 COPY entrypoint.sh /usr/local/bin
 COPY gitignore_global /root/gitignore_global
 COPY gitconfig /root/.gitconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG REGISTRY=quay.io/parkside-securities
-FROM $REGISTRY/docker-parkside-runtime:master-10
+FROM $REGISTRY/docker-parkside-runtime:master-55
 
 ENV GOROOT /usr/local/go
 ENV GOPATH /root/go

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,11 @@ RUN curl -s -LO https://github.com/kubernetes-sigs/kustomize/releases/download/k
     mv kustomize /usr/local/bin/kustomize && \
     rm kustomize_v3.3.0_linux_amd64.tar.gz && \
     chmod a+x /usr/local/bin/kustomize
+RUN curl -sL https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/graphviz.tar.gz -O && \
+    tar xvfp graphviz.tar.gz && \
+    cd  graphviz-* && \
+    ./configure && make && make install && \
+    cd - && rm -rf graphviz*
 
 ENV REDIS_VERSION=6.2.1
 RUN curl -OL https://download.redis.io/releases/redis-${REDIS_VERSION}.tar.gz && \
@@ -77,7 +82,7 @@ RUN python -m venv /usr/local/dbt-env && \
     pip install wheel && \
     pip install dbt
 RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.2.0/drone_linux_amd64.tar.gz | tar zx && \
-    install -t /usr/local/bin drone
+    mv drone /usr/local/bin/
 COPY entrypoint.sh /usr/local/bin
 COPY gitignore_global /root/gitignore_global
 COPY gitconfig /root/.gitconfig

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,12 +81,12 @@ RUN python -m venv /usr/local/dbt-env && \
     python -m pip install -U pip && \
     pip install wheel && \
     pip install dbt
-# RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.1.0/drone_linux_amd64.tar.gz | tar zx && \
-    # install -t /usr/local/bin drone
-COPY entrypoint.sh /usr/local/bin
-COPY gitignore_global /root/gitignore_global
-COPY gitconfig /root/.gitconfig
-COPY bashrc /root/.bashrc
-COPY zshrc /root/.zshrc
+RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.1.0/drone_linux_amd64.tar.gz | tar zx && \
+    install -t /usr/local/bin drone
+# COPY entrypoint.sh /usr/local/bin
+# COPY gitignore_global /root/gitignore_global
+# COPY gitconfig /root/.gitconfig
+# COPY bashrc /root/.bashrc
+# COPY zshrc /root/.zshrc
 WORKDIR /parkside
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/bashrc
+++ b/bashrc
@@ -1,6 +1,3 @@
-export PATH="/root/.pyenv/bin:$PATH"
-eval "$(pyenv init -)"
-eval "$(pyenv virtualenv-init -)"
 source /root/.kube-ps1/kube-ps1.sh
 GIT_PROMPT_ONLY_IN_REPO=1
 GIT_PROMPT_START='[$(kube_ps1)]'

--- a/drone.yml
+++ b/drone.yml
@@ -79,4 +79,3 @@ steps:
 
 image_pull_secrets:
 - dockerconfigjson
-

--- a/drone.yml
+++ b/drone.yml
@@ -69,7 +69,7 @@ steps:
       from_secret: aws_access_key_id
     secret_key:
       from_secret: aws_secret_access_key
-    repo: mono-binary-untested
+    repo: clojure-dev
     build_args_from_env:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY

--- a/drone.yml
+++ b/drone.yml
@@ -79,3 +79,4 @@ steps:
 
 image_pull_secrets:
 - dockerconfigjson
+

--- a/drone.yml
+++ b/drone.yml
@@ -19,7 +19,7 @@ docker-resources: &docker-resources
 
 steps:
 - name: create-docker-tags
-  image: 642622649254.dkr.ecr.us-west-2.amazonaws.com/clojure-dev:master
+  image: busybox:1.28
   pull: if-not-exists
   commands:
   - echo -n "${DRONE_COMMIT_BRANCH}-${DRONE_BUILD_NUMBER}" > .tags

--- a/drone.yml
+++ b/drone.yml
@@ -1,0 +1,81 @@
+kind: pipeline
+name: docker-build
+
+shell-resources: &shell-resources
+  limits:
+    cpu: 2
+    memory: 2000MiB
+  requests:
+    cpu: 0.1
+    memory: 125MiB
+
+docker-resources: &docker-resources
+  limits:
+    cpu: 4
+    memory: 2000MiB
+  requests:
+    cpu: 0.1
+    memory: 750MiB
+
+steps:
+- name: create-docker-tags
+  image: 642622649254.dkr.ecr.us-west-2.amazonaws.com/clojure-dev:master
+  pull: if-not-exists
+  commands:
+  - echo -n "${DRONE_COMMIT_BRANCH}-${DRONE_BUILD_NUMBER}" > .tags
+  resources:
+    <<: *shell-resources
+
+- name: docker-build
+  image: plugins/docker
+  pull: if-not-exists
+  depends_on: [ create-docker-tags ]
+  resources:
+    <<: *docker-resources
+  environment:
+    DOCKER_BUILDKIT: 1
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+  settings:
+    registry: quay.io
+    username:
+      from_secret: quay_username
+    password:
+      from_secret: quay_password
+    repo: quay.io/parkside-securities/clojure-dev
+    build_args_from_env:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - DRONE_COMMIT_SHA
+
+- name: docker-build-ecr
+  image: plugins/ecr
+  pull: if-not-exists
+  depends_on: [ create-docker-tags ]
+  resources:
+    <<: *docker-resources
+  environment:
+    DOCKER_BUILDKIT: 1
+    AWS_ACCESS_KEY_ID:
+      from_secret: aws_access_key_id
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: aws_secret_access_key
+  settings:
+    registry: 642622649254.dkr.ecr.us-west-2.amazonaws.com
+    region: us-west-2
+    access_key: 
+      from_secret: aws_access_key_id
+    secret_key:
+      from_secret: aws_secret_access_key
+    repo: mono-binary-untested
+    build_args_from_env:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - DRONE_COMMIT_SHA
+    build_args:
+      - REGISTRY=642622649254.dkr.ecr.us-west-2.amazonaws.com
+
+image_pull_secrets:
+- dockerconfigjson

--- a/zshrc
+++ b/zshrc
@@ -8,10 +8,6 @@ source /root/.zsh-git-prompt/zshrc.sh
 PROMPT='%B%F{2}%m%f %F{3}%~%f%b$(git_super_status)
 👉 '
 
-export PATH="/root/.pyenv/bin:$PATH"
-eval "$(pyenv init -)"
-eval "$(pyenv virtualenv-init -)"
-
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion


### PR DESCRIPTION
## Change base to corretto-clojure and deploy to ECR
And also removed some unused tools.

* Removed pyenv since it uses only 3.x installed in base image
* Removed node9 because it's deprecated in this distoribution
* Removed closh since it's supported only in node9 and it's not used from anywhere
* Add workaround for drone-cli installation and upgrade it to the version used in monorepo