### PR TITLE
fix: Stick to previous dbt version, new versions were split into multiple …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ RUN python -m venv /usr/local/dbt-env && \
     . /usr/local/dbt-env/bin/activate && \
     python -m pip install -U pip && \
     pip install wheel && \
-    pip install dbt
+    pip install dbt==0.21.1
 RUN curl -L https://github.com/drone/drone-cli/releases/download/v1.2.0/drone_linux_amd64.tar.gz | tar zx && \
     mv drone /usr/local/bin/
 RUN curl -sL https://raw.githubusercontent.com/babashka/babashka/master/install > bb-install && \


### PR DESCRIPTION
…packages

The dbt package was recently split into multiple versions and deprecated the pip installation of the "dbt" package which results in an error when building the docker image. This PR sticks the version to the version previous to the package split.